### PR TITLE
Store MT internal state as a boxed slice

### DIFF
--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -25,20 +25,15 @@ const LOWER_MASK: Wrapping<u32> = Wrapping(0x7fff_ffff);
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MT19937 {
     idx: usize,
-    state: Vec<Wrapping<u32>>, // Length `N`.
+    state: Box<[Wrapping<u32>]>, // Length `N`.
 }
-
-const UNINITIALIZED: MT19937 = MT19937 {
-    idx: 0,
-    state: Vec::new(),
-};
 
 impl SeedableRng for MT19937 {
     type Seed = [u8; 4];
 
     #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
-        let mut mt = UNINITIALIZED;
+        let mut mt = Self::uninitialized();
         mt.reseed(seed);
         mt
     }
@@ -93,6 +88,13 @@ impl RngCore for MT19937 {
 }
 
 impl MT19937 {
+    fn uninitialized() -> Self {
+        Self {
+            idx: 0,
+            state: vec![Wrapping(0); N].into_boxed_slice(),
+        }
+    }
+
     /// Create a new Mersenne Twister random number generator using
     /// the default fixed seed.
     #[inline]
@@ -125,8 +127,7 @@ impl MT19937 {
         if samples.len() != N {
             return None;
         }
-        let mut mt = UNINITIALIZED;
-        mt.state.resize(N, Wrapping(0));
+        let mut mt = Self::uninitialized();
         for (in_, out) in Iterator::zip(samples.iter().copied(), mt.state.iter_mut()) {
             *out = Wrapping(untemper(u32::from_ne_bytes(in_)));
         }
@@ -136,7 +137,6 @@ impl MT19937 {
 
     /// Reseed a Mersenne Twister from a single `u32`.
     pub fn reseed(&mut self, seed: <Self as SeedableRng>::Seed) {
-        self.state.resize(N, Wrapping(0));
         self.idx = N;
         self.state[0] = Wrapping(u32::from_ne_bytes(seed));
         for i in 1..N {

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -26,20 +26,15 @@ const LM: Wrapping<u64> = Wrapping(0x7fff_ffff); // Least significant 31 bits
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MT19937_64 {
     idx: usize,
-    state: Vec<Wrapping<u64>>, // Length `NN`
+    state: Box<[Wrapping<u64>]>, // Length `NN`
 }
-
-const UNINITIALIZED: MT19937_64 = MT19937_64 {
-    idx: 0,
-    state: Vec::new(),
-};
 
 impl SeedableRng for MT19937_64 {
     type Seed = [u8; 8];
 
     #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
-        let mut mt = UNINITIALIZED;
+        let mut mt = Self::uninitialized();
         mt.reseed(seed);
         mt
     }
@@ -95,6 +90,13 @@ impl RngCore for MT19937_64 {
 }
 
 impl MT19937_64 {
+    fn uninitialized() -> Self {
+        Self {
+            idx: 0,
+            state: vec![Wrapping(0); NN].into_boxed_slice(),
+        }
+    }
+
     /// Create a new Mersenne Twister random number generator using
     /// the default fixed seed.
     #[inline]
@@ -127,8 +129,7 @@ impl MT19937_64 {
         if samples.len() != NN {
             return None;
         }
-        let mut mt = UNINITIALIZED;
-        mt.state.resize(NN, Wrapping(0));
+        let mut mt = Self::uninitialized();
         for (in_, out) in Iterator::zip(samples.iter().copied(), mt.state.iter_mut()) {
             *out = Wrapping(untemper(u64::from_ne_bytes(in_)));
         }
@@ -138,7 +139,6 @@ impl MT19937_64 {
 
     /// Reseed a Mersenne Twister from a single `u64`.
     pub fn reseed(&mut self, seed: <Self as SeedableRng>::Seed) {
-        self.state.resize(NN, Wrapping(0));
         self.idx = NN;
         self.state[0] = Wrapping(u64::from_ne_bytes(seed));
         for i in 1..NN {


### PR DESCRIPTION
The vector doesnt and cannot grow to ensure correctness.

This PR replaces the const `UNINITIALIZED` struct with an
`uninitialized` function that returns a properly sized state.