### PR TITLE
Lint with clippy pedantic mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,12 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
+#![deny(clippy::all)]
+#![deny(clippy::pedantic)]
+#![deny(missing_docs, intra_doc_link_resolution_failure)]
+#![warn(rust_2018_idioms)]
+#![forbid(unsafe_code)]
+
 //! # Mersenne Twister
 //!
 //! A pure rust port of the Mersenne Twister pseudorandom number

--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -126,7 +126,8 @@ impl MT19937 {
     /// subsequent outputs of the RNG that was sampled.
     ///
     /// Returns `None` if `samples` is not exactly 624 elements.
-    pub fn recover(samples: &[u32]) -> Option<MT19937> {
+    #[must_use]
+    pub fn recover(samples: &[u32]) -> Option<Self> {
         if samples.len() != N {
             return None;
         }

--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -9,6 +9,7 @@
 // modified, or distributed except according to those terms.
 
 use std::cmp;
+use std::convert::TryFrom;
 use std::num::Wrapping;
 
 use rand_core::{RngCore, SeedableRng};
@@ -31,10 +32,11 @@ pub struct MT19937 {
 impl SeedableRng for MT19937 {
     type Seed = [u8; 4];
 
+    /// Reseed from a little endian encoded `u32`.
     #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         let mut mt = Self::uninitialized();
-        mt.reseed(seed);
+        mt.reseed(u32::from_le_bytes(seed));
         mt
     }
 }
@@ -63,7 +65,7 @@ impl RngCore for MT19937 {
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         let mut bytes_written = 0;
         loop {
-            let bytes = self.next_u32().to_ne_bytes();
+            let bytes = self.next_u32().to_le_bytes();
             if let Some(slice) = dest.get_mut(bytes_written..bytes_written + 4) {
                 slice.copy_from_slice(&bytes[..]);
                 bytes_written += 4;
@@ -98,8 +100,9 @@ impl MT19937 {
     /// Create a new Mersenne Twister random number generator using
     /// the default fixed seed.
     #[inline]
+    #[must_use]
     pub fn new_unseeded() -> Self {
-        Self::from_seed(5489_u32.to_ne_bytes())
+        Self::from_seed(5489_u32.to_le_bytes())
     }
 
     fn fill_next_state(&mut self) {
@@ -123,26 +126,26 @@ impl MT19937 {
     /// subsequent outputs of the RNG that was sampled.
     ///
     /// Returns `None` if `samples` is not exactly 624 elements.
-    pub fn recover(samples: &[<Self as SeedableRng>::Seed]) -> Option<MT19937> {
+    pub fn recover(samples: &[u32]) -> Option<MT19937> {
         if samples.len() != N {
             return None;
         }
         let mut mt = Self::uninitialized();
         for (in_, out) in Iterator::zip(samples.iter().copied(), mt.state.iter_mut()) {
-            *out = Wrapping(untemper(u32::from_ne_bytes(in_)));
+            *out = Wrapping(untemper(in_));
         }
         mt.idx = N;
         Some(mt)
     }
 
     /// Reseed a Mersenne Twister from a single `u32`.
-    pub fn reseed(&mut self, seed: <Self as SeedableRng>::Seed) {
+    pub fn reseed(&mut self, seed: u32) {
         self.idx = N;
-        self.state[0] = Wrapping(u32::from_ne_bytes(seed));
+        self.state[0] = Wrapping(seed);
         for i in 1..N {
             self.state[i] = Wrapping(1_812_433_253)
                 * (self.state[i - 1] ^ (self.state[i - 1] >> 30))
-                + Wrapping(i as u32);
+                + Wrapping(u32::try_from(i).unwrap_or_default());
         }
     }
 
@@ -150,15 +153,15 @@ impl MT19937 {
     ///
     /// This method can be used to reconstruct a PRNG's internal state from an
     /// observed sequence of random numbers.
-    pub fn reseed_from_slice(&mut self, key: &[<Self as SeedableRng>::Seed]) {
-        self.reseed(19_650_218_u32.to_ne_bytes());
-        let mut i = 1;
-        let mut j = 0;
+    pub fn reseed_from_slice(&mut self, key: &[u32]) {
+        self.reseed(19_650_218_u32);
+        let mut i = 1_usize;
+        let mut j = 0_usize;
         for _ in 0..cmp::max(N, key.len()) {
             self.state[i] = (self.state[i]
                 ^ ((self.state[i - 1] ^ (self.state[i - 1] >> 30)) * Wrapping(1_664_525)))
-                + Wrapping(u32::from_ne_bytes(key[j]))
-                + Wrapping(j as u32);
+                + Wrapping(key[j])
+                + Wrapping(u32::try_from(j).unwrap_or_default());
             i += 1;
             if i >= N {
                 self.state[0] = self.state[N - 1];
@@ -172,7 +175,7 @@ impl MT19937 {
         for _ in 0..N - 1 {
             self.state[i] = (self.state[i]
                 ^ ((self.state[i - 1] ^ (self.state[i - 1] >> 30)) * Wrapping(1_566_083_941)))
-                - Wrapping(i as u32);
+                - Wrapping(u32::try_from(i).unwrap_or_default());
             i += 1;
             if i >= N {
                 self.state[0] = self.state[N - 1];
@@ -232,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_32bit_seeded() {
-        let mt = MT19937::from_seed(0x1234_5678_u32.to_ne_bytes());
+        let mt = MT19937::from_seed(0x1234_5678_u32.to_le_bytes());
         for (&Wrapping(x), &y) in mt.state.iter().zip(vectors::STATE_SEEDED_BY_U32.iter()) {
             assert!(x == y);
         }
@@ -241,14 +244,7 @@ mod tests {
     #[test]
     fn test_32bit_slice_seeded() {
         let mut mt = MT19937::default();
-        mt.reseed_from_slice(
-            &[
-                0x123_u32.to_ne_bytes(),
-                0x234_u32.to_ne_bytes(),
-                0x345_u32.to_ne_bytes(),
-                0x456_u32.to_ne_bytes(),
-            ][..],
-        );
+        mt.reseed_from_slice(&[0x123_u32, 0x234_u32, 0x345_u32, 0x456_u32][..]);
         for (&Wrapping(x), &y) in mt.state.iter().zip(vectors::STATE_SEEDED_BY_SLICE.iter()) {
             assert!(x == y);
         }
@@ -257,14 +253,7 @@ mod tests {
     #[test]
     fn test_32bit_output() {
         let mut mt = MT19937::default();
-        mt.reseed_from_slice(
-            &[
-                0x123_u32.to_ne_bytes(),
-                0x234_u32.to_ne_bytes(),
-                0x345_u32.to_ne_bytes(),
-                0x456_u32.to_ne_bytes(),
-            ][..],
-        );
+        mt.reseed_from_slice(&[0x123_u32, 0x234_u32, 0x345_u32, 0x456_u32][..]);
         for x in vectors::TEST_OUTPUT.iter() {
             assert!(mt.next_u32() == *x);
         }
@@ -277,14 +266,14 @@ mod tests {
 
     #[quickcheck]
     fn test_recovery(seed: u32, skip: u8) -> bool {
-        let mut orig_mt = MT19937::from_seed(seed.to_ne_bytes());
+        let mut orig_mt = MT19937::from_seed(seed.to_le_bytes());
         // skip some samples so the RNG is in an intermediate state
         for _ in 0..skip {
             orig_mt.next_u64();
         }
         let mut samples = Vec::with_capacity(super::N);
         for _ in 0..super::N {
-            samples.push(orig_mt.next_u32().to_ne_bytes());
+            samples.push(orig_mt.next_u32());
         }
         let mut recovered_mt = MT19937::recover(&samples[..]).unwrap();
         for _ in 0..super::N * 2 {

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn test_64bit_slice_seeded() {
         let mut mt = MT19937_64::default();
-        mt.reseed_from_slice(&[0x12345u64, 0x23456u64, 0x34567u64, 0x45678u64][..]);
+        mt.reseed_from_slice(&[0x12345_u64, 0x23456_u64, 0x34567_u64, 0x45678_u64][..]);
         for (&Wrapping(x), &y) in mt.state.iter().zip(vectors::STATE_SEEDED_BY_SLICE.iter()) {
             assert!(x == y);
         }
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn test_64bit_output() {
         let mut mt = MT19937_64::default();
-        mt.reseed_from_slice(&[0x12345u64, 0x23456u64, 0x34567u64, 0x45678u64][..]);
+        mt.reseed_from_slice(&[0x12345_u64, 0x23456_u64, 0x34567_u64, 0x45678_u64][..]);
         for x in vectors::TEST_OUTPUT.iter() {
             assert!(mt.next_u64() == *x);
         }

--- a/src/mt19937_64.rs
+++ b/src/mt19937_64.rs
@@ -32,16 +32,18 @@ pub struct MT19937_64 {
 impl SeedableRng for MT19937_64 {
     type Seed = [u8; 8];
 
+    /// Reseed from a little endian encoded `u64`.
     #[inline]
     fn from_seed(seed: Self::Seed) -> Self {
         let mut mt = Self::uninitialized();
-        mt.reseed(seed);
+        mt.reseed(u64::from_le_bytes(seed));
         mt
     }
 }
 
 impl RngCore for MT19937_64 {
     #[inline]
+    #[allow(clippy::cast_possible_truncation)]
     fn next_u32(&mut self) -> u32 {
         self.next_u64() as u32
     }
@@ -65,7 +67,7 @@ impl RngCore for MT19937_64 {
             if bytes_written >= dest.len() {
                 break;
             }
-            let bytes = self.next_u64().to_ne_bytes();
+            let bytes = self.next_u64().to_le_bytes();
             if let Some(slice) = dest.get_mut(bytes_written..bytes_written + 8) {
                 slice.copy_from_slice(&bytes[..]);
                 bytes_written += 8;
@@ -100,8 +102,9 @@ impl MT19937_64 {
     /// Create a new Mersenne Twister random number generator using
     /// the default fixed seed.
     #[inline]
+    #[must_use]
     pub fn new_unseeded() -> Self {
-        Self::from_seed(5489_u64.to_ne_bytes())
+        Self::from_seed(5489_u64.to_le_bytes())
     }
 
     fn fill_next_state(&mut self) {
@@ -125,22 +128,23 @@ impl MT19937_64 {
     /// reproduce subsequent outputs of the RNG that was sampled.
     ///
     /// Returns `None` if `samples` is not exactly 312 elements.
-    pub fn recover(samples: &[<Self as SeedableRng>::Seed]) -> Option<Self> {
+    #[must_use]
+    pub fn recover(samples: &[u64]) -> Option<Self> {
         if samples.len() != NN {
             return None;
         }
         let mut mt = Self::uninitialized();
         for (in_, out) in Iterator::zip(samples.iter().copied(), mt.state.iter_mut()) {
-            *out = Wrapping(untemper(u64::from_ne_bytes(in_)));
+            *out = Wrapping(untemper(in_));
         }
         mt.idx = NN;
         Some(mt)
     }
 
     /// Reseed a Mersenne Twister from a single `u64`.
-    pub fn reseed(&mut self, seed: <Self as SeedableRng>::Seed) {
+    pub fn reseed(&mut self, seed: u64) {
         self.idx = NN;
-        self.state[0] = Wrapping(u64::from_ne_bytes(seed));
+        self.state[0] = Wrapping(seed);
         for i in 1..NN {
             self.state[i] = Wrapping(6_364_136_223_846_793_005)
                 * (self.state[i - 1] ^ (self.state[i - 1] >> 62))
@@ -152,15 +156,15 @@ impl MT19937_64 {
     ///
     /// This method can be used to reconstruct a PRNG's internal state from an
     /// observed sequence of random numbers.
-    pub fn reseed_from_slice(&mut self, key: &[<Self as SeedableRng>::Seed]) {
-        self.reseed(19_650_218_u64.to_ne_bytes());
+    pub fn reseed_from_slice(&mut self, key: &[u64]) {
+        self.reseed(19_650_218_u64);
         let mut i = 1;
         let mut j = 0;
         for _ in 0..cmp::max(NN, key.len()) {
             self.state[i] = (self.state[i]
                 ^ ((self.state[i - 1] ^ (self.state[i - 1] >> 62))
                     * Wrapping(3_935_559_000_370_003_845)))
-                + Wrapping(u64::from_ne_bytes(key[j]))
+                + Wrapping(key[j])
                 + Wrapping(j as u64);
             i += 1;
             if i >= NN {
@@ -234,7 +238,7 @@ mod tests {
 
     #[test]
     fn test_64bit_seeded() {
-        let mt = MT19937_64::from_seed(0x0123_4567_89ab_cdef_u64.to_ne_bytes());
+        let mt = MT19937_64::from_seed(0x0123_4567_89ab_cdef_u64.to_le_bytes());
         for (&Wrapping(x), &y) in mt.state.iter().zip(vectors::STATE_SEEDED_BY_U64.iter()) {
             assert!(x == y);
         }
@@ -243,14 +247,7 @@ mod tests {
     #[test]
     fn test_64bit_slice_seeded() {
         let mut mt = MT19937_64::default();
-        mt.reseed_from_slice(
-            &[
-                0x12345_u64.to_ne_bytes(),
-                0x23456_u64.to_ne_bytes(),
-                0x34567_u64.to_ne_bytes(),
-                0x45678_u64.to_ne_bytes(),
-            ][..],
-        );
+        mt.reseed_from_slice(&[0x12345u64, 0x23456u64, 0x34567u64, 0x45678u64][..]);
         for (&Wrapping(x), &y) in mt.state.iter().zip(vectors::STATE_SEEDED_BY_SLICE.iter()) {
             assert!(x == y);
         }
@@ -259,14 +256,7 @@ mod tests {
     #[test]
     fn test_64bit_output() {
         let mut mt = MT19937_64::default();
-        mt.reseed_from_slice(
-            &[
-                0x12345_u64.to_ne_bytes(),
-                0x23456_u64.to_ne_bytes(),
-                0x34567_u64.to_ne_bytes(),
-                0x45678_u64.to_ne_bytes(),
-            ][..],
-        );
+        mt.reseed_from_slice(&[0x12345u64, 0x23456u64, 0x34567u64, 0x45678u64][..]);
         for x in vectors::TEST_OUTPUT.iter() {
             assert!(mt.next_u64() == *x);
         }
@@ -279,14 +269,14 @@ mod tests {
 
     #[quickcheck]
     fn test_recovery(seed: u64, skip: u8) -> bool {
-        let mut orig_mt = MT19937_64::from_seed(seed.to_ne_bytes());
+        let mut orig_mt = MT19937_64::from_seed(seed.to_le_bytes());
         // skip some samples so the RNG is in an intermediate state
         for _ in 0..skip {
             orig_mt.next_u64();
         }
         let mut samples = Vec::with_capacity(super::NN);
         for _ in 0..super::NN {
-            samples.push(orig_mt.next_u64().to_ne_bytes());
+            samples.push(orig_mt.next_u64());
         }
         let mut recovered_mt = MT19937_64::recover(&samples[..]).unwrap();
         for _ in 0..super::NN * 2 {


### PR DESCRIPTION
- Add warn prelude to lib.rs.
- forbid unsafe code.
- Standardize that `seed` should always be little endian encoded.
- Modify methods outside of `rand_core` impls to take `u32` and `u64`
  directly.
- avoid wrapping integer casts and use `TryFrom` instead.